### PR TITLE
Add periodic test run scheduler

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,6 +335,24 @@ Pyctuator(
 Since there are numerous standard approaches to protect an API, Pyctuator doesn't explicitly support any of them. Instead, Pyctuator allows to customize its integration with the web-framework.
 See the example in [fastapi_with_authentication_example_app.py](examples/FastAPI/fastapi_with_authentication_example_app.py).
 
+### Periodic test runs
+Pyctuator can optionally execute your project's test-suite on a schedule.
+When enabled, Pyctuator spawns a background thread that periodically runs
+``pytest`` and stores the generated ``coverage.json`` and ``test_report.json``
+artifacts.  Set the environment variable ``PYCTUATOR_TEST_SCHEDULE_INTERVAL``
+to the desired interval in seconds.  To automatically upload the JSON
+payload to a remote server set ``PYCTUATOR_TEST_UPLOAD_URL`` to the desired
+URL.
+
+```bash
+export PYCTUATOR_TEST_SCHEDULE_INTERVAL=3600
+export PYCTUATOR_TEST_UPLOAD_URL="http://example.com/upload"
+```
+
+The generated artifacts are written to ``PyctuatorImpl.test_results_path``
+which defaults to the ``test_results`` directory in the current working
+directory.
+
 ## Full blown examples
 The `examples` folder contains full blown Python projects that are built using [Poetry](https://python-poetry.org/).
 

--- a/examples/test_scheduler_example.py
+++ b/examples/test_scheduler_example.py
@@ -1,0 +1,32 @@
+"""Minimal example demonstrating the test run scheduler.
+
+Set ``PYCTUATOR_TEST_SCHEDULE_INTERVAL`` and optionally
+``PYCTUATOR_TEST_UPLOAD_URL`` before running this script to enable the
+scheduler.  The scheduler will periodically execute ``pytest`` and save
+its artifacts under ``test_results``.
+"""
+
+import time
+
+from pyctuator.endpoints import Endpoints
+from pyctuator.impl.pyctuator_impl import AppDetails, AppInfo, PyctuatorImpl
+
+
+# Instantiate Pyctuator which will automatically start the scheduler when
+# the environment variable is configured.
+pyctuator = PyctuatorImpl(
+    app_info=AppInfo(app=AppDetails(name="scheduler-example")),
+    pyctuator_endpoint_url="http://localhost/pyctuator",
+    logfile_max_size=0,
+    logfile_formatter="",  # no log file
+    additional_app_info=None,
+    disabled_endpoints=Endpoints.NONE,
+)
+
+# Keep the application alive for a short while so the scheduler can run.
+print("Scheduler started; sleeping for 10 seconds...")
+try:
+    time.sleep(10)
+finally:
+    if pyctuator.test_scheduler:
+        pyctuator.test_scheduler.stop()

--- a/pyctuator/impl/pyctuator_impl.py
+++ b/pyctuator/impl/pyctuator_impl.py
@@ -1,6 +1,8 @@
 import dataclasses
 from dataclasses import dataclass
 from datetime import datetime
+import os
+from pathlib import Path
 from typing import List, Dict, Mapping, Optional, Callable
 from urllib.parse import urlparse
 
@@ -12,6 +14,7 @@ from pyctuator.httptrace.http_tracer import HttpTracer
 from pyctuator.logfile.logfile import PyctuatorLogfile  # type: ignore
 from pyctuator.logging.pyctuator_logging import PyctuatorLogging
 from pyctuator.metrics.metrics_provider import Metric, MetricNames, MetricsProvider
+from pyctuator.testing.scheduler import TestRunScheduler
 from pyctuator.threads.thread_dump_provider import ThreadDump, ThreadDumpProvider
 
 
@@ -75,10 +78,30 @@ class PyctuatorImpl:
 
         self.secret_scrubber: Callable[[Dict], Dict] = SecretScrubber().scrub_secrets
 
+        # path where test artifacts should be stored
+        self.test_results_path = Path(
+            os.getenv("PYCTUATOR_TEST_RESULTS_PATH", "test_results")
+        )
+        self.test_scheduler: Optional[TestRunScheduler] = None
+
         # Determine the endpoint's URL path prefix and make sure it doesn't end with a "/"
         self.pyctuator_endpoint_path_prefix = urlparse(pyctuator_endpoint_url).path
         if self.pyctuator_endpoint_path_prefix[-1:] == "/":
             self.pyctuator_endpoint_path_prefix = self.pyctuator_endpoint_path_prefix[:-1]
+
+        # Start the test run scheduler if configured
+        interval_env = os.getenv("PYCTUATOR_TEST_SCHEDULE_INTERVAL")
+        if interval_env:
+            try:
+                interval = int(interval_env)
+                if interval > 0:
+                    upload_url = os.getenv("PYCTUATOR_TEST_UPLOAD_URL")
+                    self.test_scheduler = TestRunScheduler(
+                        interval, upload_url, self.test_results_path
+                    )
+                    self.test_scheduler.start()
+            except ValueError:
+                pass
 
     def register_metrics_provider(self, provider: MetricsProvider) -> None:
         self.metrics_providers.append(provider)

--- a/pyctuator/testing/__init__.py
+++ b/pyctuator/testing/__init__.py
@@ -1,0 +1,1 @@
+"""Testing utilities for Pyctuator."""

--- a/pyctuator/testing/scheduler.py
+++ b/pyctuator/testing/scheduler.py
@@ -1,0 +1,115 @@
+"""Test run scheduler for Pyctuator.
+
+This module provides :class:`TestRunScheduler` which can be used to
+periodically execute the project's test-suite.  The tests are executed
+using ``pytest`` and the resulting artifacts are stored under the given
+``results_path``.  Optionally the results can be uploaded to a remote
+HTTP server.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+import time
+from pathlib import Path
+from typing import Callable, Optional
+
+import requests
+
+# We intentionally import subprocess only after typing to ease testing
+import subprocess  # noqa: E402  (imported late on purpose)
+
+
+class TestRunScheduler:
+    """Periodically execute the project's tests in a background thread.
+
+    The scheduler runs ``pytest`` in a subprocess and stores the JSON
+    coverage report and the JSON test report under ``results_path``.  If an
+    ``upload_url`` is supplied, the two reports are merged and uploaded to
+    the server using an HTTP POST request.  Failures while running the
+    tests or while uploading the results never raise exceptions to the
+    caller.
+    """
+
+    __test__ = False  # prevent pytest from collecting this class as a test
+
+    def __init__(
+        self,
+        interval_seconds: int,
+        upload_url: Optional[str],
+        results_path: Path,
+        subprocess_run: Callable[..., subprocess.CompletedProcess] = subprocess.run,
+        post: Callable[..., requests.Response] = requests.post,
+    ) -> None:
+        self.interval_seconds = interval_seconds
+        self.upload_url = upload_url
+        self.results_path = Path(results_path)
+        self._subprocess_run = subprocess_run
+        self._post = post
+        self._thread: Optional[threading.Thread] = None
+        self._stop_event = threading.Event()
+
+    def start(self) -> None:
+        """Start the scheduler in a daemon thread."""
+        if self._thread is None:
+            self._thread = threading.Thread(target=self._run_loop, daemon=True)
+            self._thread.start()
+
+    def stop(self) -> None:
+        """Stop the scheduler and wait for the thread to finish."""
+        if self._thread is not None:
+            self._stop_event.set()
+            self._thread.join(timeout=self.interval_seconds + 1)
+            self._thread = None
+            self._stop_event.clear()
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _run_loop(self) -> None:
+        while not self._stop_event.is_set():
+            self.run_tests()
+            # Wait for interval or until stop event is set
+            self._stop_event.wait(self.interval_seconds)
+
+    def run_tests(self) -> None:
+        """Execute the tests once and optionally upload the results."""
+        self.results_path.mkdir(parents=True, exist_ok=True)
+        coverage_file = self.results_path / "coverage.json"
+        report_file = self.results_path / "test_report.json"
+        cmd = [
+            "pytest",
+            "--cov=.",
+            f"--cov-report=json:{coverage_file}",
+            "--json-report",
+            f"--json-report-file={report_file}",
+        ]
+        # Execute tests but never raise an exception
+        self._subprocess_run(cmd, check=False)
+
+        if self.upload_url:
+            payload = {}
+            try:
+                if coverage_file.exists():
+                    with coverage_file.open("r", encoding="utf-8") as cov_fd:
+                        payload["coverage"] = json.load(cov_fd)
+                if report_file.exists():
+                    with report_file.open("r", encoding="utf-8") as rep_fd:
+                        payload["report"] = json.load(rep_fd)
+
+                self._post_with_retry(payload)
+            except Exception:
+                # Swallow all exceptions – the scheduler should never crash the app
+                pass
+
+    def _post_with_retry(self, payload: dict) -> None:
+        for _ in range(3):
+            try:
+                response = self._post(self.upload_url, json=payload, timeout=10)
+                if response.ok:
+                    return
+            except Exception:
+                time.sleep(1)
+        # Silently give up after retries
+        return

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1,0 +1,57 @@
+import threading
+from typing import List
+
+import subprocess
+
+from pyctuator.testing.scheduler import TestRunScheduler
+
+
+def test_scheduler_spawns_and_invokes_pytest(tmp_path):
+    called = threading.Event()
+
+    def fake_run(cmd, check=False):  # noqa: ARG001 - signature for subprocess.run
+        if cmd[0] == "pytest":
+            called.set()
+        return subprocess.CompletedProcess(cmd, 0)
+
+    scheduler = TestRunScheduler(0.1, None, tmp_path, subprocess_run=fake_run)
+    scheduler.start()
+    assert called.wait(1), "pytest was not invoked by scheduler"
+    scheduler.stop()
+
+
+def test_subprocess_failure_does_not_crash(tmp_path):
+    def failing_run(cmd, check=False):  # noqa: ARG001 - signature for subprocess.run
+        return subprocess.CompletedProcess(cmd, 1)
+
+    scheduler = TestRunScheduler(0.1, None, tmp_path, subprocess_run=failing_run)
+    # Should not raise even though return code indicates failure
+    scheduler.run_tests()
+
+
+def test_artifacts_and_upload(tmp_path):
+    def fake_run(cmd, check=False):  # noqa: ARG001 - signature for subprocess.run
+        (tmp_path / "coverage.json").write_text("{}", encoding="utf-8")
+        (tmp_path / "test_report.json").write_text("{}", encoding="utf-8")
+        return subprocess.CompletedProcess(cmd, 0)
+
+    posts: List[dict] = []
+
+    def fake_post(url, json, timeout):  # noqa: ARG001 - signature for requests.post
+        posts.append(json)
+        class Resp:
+            ok = True
+        return Resp()
+
+    scheduler = TestRunScheduler(
+        0.1,
+        "http://server/upload",
+        tmp_path,
+        subprocess_run=fake_run,
+        post=fake_post,
+    )
+    scheduler.run_tests()
+
+    assert (tmp_path / "coverage.json").exists()
+    assert (tmp_path / "test_report.json").exists()
+    assert posts, "expected a POST request to be attempted"


### PR DESCRIPTION
## Summary
- add `TestRunScheduler` to run pytest in a background thread and optionally upload results
- start scheduler via `PYCTUATOR_TEST_SCHEDULE_INTERVAL` and `PYCTUATOR_TEST_UPLOAD_URL` env vars
- document usage and provide example

## Testing
- `pytest tests/test_scheduler.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b944cfb474832d8c9b6ad4b4ef90da